### PR TITLE
Uses the interval constant for printing ⏲

### DIFF
--- a/firmware/examples/carloop_minimal.cpp
+++ b/firmware/examples/carloop_minimal.cpp
@@ -47,7 +47,7 @@ void printValuesAtInterval() {
     static const unsigned long interval = 1000;
 
     static unsigned long lastDisplay = 0;
-    if(millis() - lastDisplay < 1000)
+    if(millis() - lastDisplay < interval)
     {
         return;
     }


### PR DESCRIPTION
I noticed this when hacking on my carloop.
I wanted to print these values less often, changed the value of interval,
but continued to see it printed every second. 😀
